### PR TITLE
Revert "Revert "Change in tests "Altom" name in imports for C# package""

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ This repository shows a few C# tests that use the page object model and AltTeste
 https://assetstore.unity.com/packages/essentials/tutorial-projects/endless-runner-sample-game-87901
 
 ### Running the tests on Android
-The tests are meant to be run on an Adroid device. Create a folder app under project
 
-The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip and needs to be included unzipped under the app/ folder.
-
-To start the tests, depending of your OS run:
- - ./run_tests_mac.sh on MacOS/Linux
- - ./run_tests_windows.sh on Windows
+1. Install the [AltTesterDesktop](https://alttester.com/alttester/#pricing), then open it (you need to accept the Terms and Conditions if the AltTester is opened for the first time).
+2. The tests are meant to be run on an Adroid device. Create a folder `app` under project. The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip and needs to be included unzipped under the `app/` folder.
+3. To start the tests, depending of your OS run:
+    - `./run_tests_mac.sh on MacOS/Linux`
+    - `./run_tests_windows.sh on Windows`
 
 This script will:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://assetstore.unity.com/packages/essentials/tutorial-projects/endless-runne
 
 1. Install the [AltTesterDesktop](https://alttester.com/alttester/#pricing), then open it (you need to accept the Terms and Conditions if the AltTester is opened for the first time).
 2. The tests are meant to be run on an Adroid device. Create a folder `app` under project. The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip and needs to be included unzipped under the `app/` folder.
-3. To start the tests, depending of your OS run:
+3. To start the tests, depending on your OS run:
     - `./run_tests_mac.sh on MacOS/Linux`
     - `./run_tests_windows.sh on Windows`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://assetstore.unity.com/packages/essentials/tutorial-projects/endless-runne
 ### Running the tests on Android
 The tests are meant to be run on an Adroid device. Create a folder app under project
 
-The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCatAndroid.zip and needs to be included unzipped under the app/ folder.
+The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip and needs to be included unzipped under the app/ folder.
 
 To start the tests, depending of your OS run:
  - ./run_tests_mac.sh on MacOS/Linux

--- a/TestsAltTrashCatCSharp/Tests/GamePlayTests.cs
+++ b/TestsAltTrashCatCSharp/Tests/GamePlayTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using Altom.AltDriver;
+using AltTester.AltDriver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/TestsAltTrashCatCSharp/Tests/GamePlayTests.cs
+++ b/TestsAltTrashCatCSharp/Tests/GamePlayTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/TestsAltTrashCatCSharp/Tests/MainMenuTests.cs
+++ b/TestsAltTrashCatCSharp/Tests/MainMenuTests.cs
@@ -1,7 +1,7 @@
-using Altom.AltDriver;
-using alttrashcat_tests_csharp.pages;
 using System;
 using System.Threading;
+using AltTester.AltDriver;
+using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 namespace alttrashcat_tests_csharp.tests
 {

--- a/TestsAltTrashCatCSharp/Tests/MainMenuTests.cs
+++ b/TestsAltTrashCatCSharp/Tests/MainMenuTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 namespace alttrashcat_tests_csharp.tests

--- a/TestsAltTrashCatCSharp/Tests/StartPageTests.cs
+++ b/TestsAltTrashCatCSharp/Tests/StartPageTests.cs
@@ -1,7 +1,7 @@
-using Altom.AltDriver;
-using alttrashcat_tests_csharp.pages;
 using System;
 using System.Threading;
+using AltTester.AltDriver;
+using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 
 namespace alttrashcat_tests_csharp.tests

--- a/TestsAltTrashCatCSharp/Tests/StartPageTests.cs
+++ b/TestsAltTrashCatCSharp/Tests/StartPageTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/TestsAltTrashCatCSharp/TestsAltTrashCatCSharp.csproj
+++ b/TestsAltTrashCatCSharp/TestsAltTrashCatCSharp.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AltTester-Driver" Version="1.8.0" />
+    <PackageReference Include="AltTester-Driver" Version="2.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/TestsAltTrashCatCSharp/pages/BasePage.cs
+++ b/TestsAltTrashCatCSharp/pages/BasePage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/BasePage.cs
+++ b/TestsAltTrashCatCSharp/pages/BasePage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/GamePlay.cs
+++ b/TestsAltTrashCatCSharp/pages/GamePlay.cs
@@ -1,5 +1,5 @@
-using Altom.AltDriver;
 using System;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {
@@ -29,27 +29,27 @@ namespace alttrashcat_tests_csharp.pages
             return Character.GetComponentProperty<int>("CharacterInputController", "currentLife", "Assembly-CSharp");
         }
         public void Jump(AltObject character)
-            {
-                character.CallComponentMethod<string>("CharacterInputController", "Jump", "Assembly-CSharp", new object[]{});
-            }
+        {
+            character.CallComponentMethod<string>("CharacterInputController", "Jump", "Assembly-CSharp", new object[] { });
+        }
         public void Slide(AltObject character)
-            {
-                character.CallComponentMethod<string>("CharacterInputController", "Slide", "Assembly-CSharp", new object[]{});
-            }        
+        {
+            character.CallComponentMethod<string>("CharacterInputController", "Slide", "Assembly-CSharp", new object[] { });
+        }
         public void MoveRight(AltObject character)
-        { 
-            character.CallComponentMethod<string>("CharacterInputController", "ChangeLane", "Assembly-CSharp", new string[]{"1"});
+        {
+            character.CallComponentMethod<string>("CharacterInputController", "ChangeLane", "Assembly-CSharp", new string[] { "1" });
         }
         public void MoveLeft(AltObject character)
-        { 
-            character.CallComponentMethod<string>("CharacterInputController", "ChangeLane", "Assembly-CSharp", new string[]{"-1"});
+        {
+            character.CallComponentMethod<string>("CharacterInputController", "ChangeLane", "Assembly-CSharp", new string[] { "-1" });
         }
         public void AvoidObstacles(int numberOfObstacles)
         {
             var character = Character;
             bool movedLeft = false;
             bool movedRight = false;
-            character.CallComponentMethod<string>("CharacterInputController", "CheatInvincible",  "Assembly-CSharp", new string[]{"true"});
+            character.CallComponentMethod<string>("CharacterInputController", "CheatInvincible", "Assembly-CSharp", new string[] { "true" });
             for (int i = 0; i < numberOfObstacles; i++)
             {
                 var allObstacles = Driver.FindObjectsWhichContain(By.NAME, "Obstacle");
@@ -133,9 +133,9 @@ namespace alttrashcat_tests_csharp.pages
                     MoveRight(character);
                     movedRight = false;
                 }
-                
+
             }
-            character.CallComponentMethod<string>("CharacterInputController", "CheatInvincible",  "Assembly-CSharp", new string[]{"false"});
+            character.CallComponentMethod<string>("CharacterInputController", "CheatInvincible", "Assembly-CSharp", new string[] { "false" });
         }
     }
 }

--- a/TestsAltTrashCatCSharp/pages/GamePlay.cs
+++ b/TestsAltTrashCatCSharp/pages/GamePlay.cs
@@ -1,5 +1,5 @@
 using System;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/GetAnotherChancePage.cs
+++ b/TestsAltTrashCatCSharp/pages/GetAnotherChancePage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/GetAnotherChancePage.cs
+++ b/TestsAltTrashCatCSharp/pages/GetAnotherChancePage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/MainMenuPage.cs
+++ b/TestsAltTrashCatCSharp/pages/MainMenuPage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/MainMenuPage.cs
+++ b/TestsAltTrashCatCSharp/pages/MainMenuPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/PauseOverlayPage.cs
+++ b/TestsAltTrashCatCSharp/pages/PauseOverlayPage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/PauseOverlayPage.cs
+++ b/TestsAltTrashCatCSharp/pages/PauseOverlayPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/StartPage.cs
+++ b/TestsAltTrashCatCSharp/pages/StartPage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestsAltTrashCatCSharp/pages/StartPage.cs
+++ b/TestsAltTrashCatCSharp/pages/StartPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {


### PR DESCRIPTION
Reverts alttester/EXAMPLES-CSharp-Android-AltTrahCat#4
In this PR will be done:
- Change in tests "Altom" name in imports for C# package
- Update the builds and the readme (with changes from 2.0.1)
- The driver will pe updated to 2.0.1
- The dotnet will be updated to 7
Results after changes:
![image](https://github.com/alttester/EXAMPLES-CSharp-Android-AltTrahCat/assets/113912901/091ce87e-84a1-4c7a-b73c-baca59bc96d8)
