### PR TITLE
[Android-C#] Update example to avoid the confusion regarding using of the By class

### DIFF
--- a/TestsAltTrashCatCSharp/pages/GamePlay.cs
+++ b/TestsAltTrashCatCSharp/pages/GamePlay.cs
@@ -9,7 +9,7 @@ namespace alttrashcat_tests_csharp.pages
         {
         }
 
-        public AltObject PauseButton { get => Driver.WaitForObject(By.NAME, "Game/WholeUI/pauseButton", timeout: 2); }
+        public AltObject PauseButton { get => Driver.WaitForObject(By.NAME, "pauseButton", timeout: 2); }
         public AltObject Character { get => Driver.WaitForObject(By.NAME, "PlayerPivot"); }
 
         public bool IsDisplayed()

--- a/TestsAltTrashCatCSharp/pages/GetAnotherChancePage.cs
+++ b/TestsAltTrashCatCSharp/pages/GetAnotherChancePage.cs
@@ -8,9 +8,9 @@ namespace alttrashcat_tests_csharp.pages
         {
         }
 
-        public AltObject GameOverButton { get => Driver.WaitForObject(By.NAME, "Game/DeathPopup/GameOver", timeout: 2); }
-        public AltObject PremiumButton { get => Driver.WaitForObject(By.NAME, "Game/DeathPopup/ButtonLayout/Premium Button", timeout: 2); }
-        public AltObject AvailableCurrency { get => Driver.WaitForObject(By.NAME, "Game/DeathPopup/PremiumDisplay/PremiumOwnCount", timeout: 2); }
+        public AltObject GameOverButton { get => Driver.WaitForObject(By.NAME, "GameOver", timeout: 2); }
+        public AltObject PremiumButton { get => Driver.WaitForObject(By.NAME, "Premium Button", timeout: 2); }
+        public AltObject AvailableCurrency { get => Driver.WaitForObject(By.NAME, "PremiumOwnCount", timeout: 2); }
 
         public bool IsDisplayed()
         {

--- a/TestsAltTrashCatCSharp/pages/MainMenuPage.cs
+++ b/TestsAltTrashCatCSharp/pages/MainMenuPage.cs
@@ -12,13 +12,13 @@ namespace alttrashcat_tests_csharp.pages
             Driver.LoadScene("Main");
         }
 
-        public AltObject StoreButton { get => Driver.WaitForObject(By.NAME, "UICamera/Loadout/StoreButton", timeout: 10); }
-        public AltObject LeaderBoardButton { get => Driver.WaitForObject(By.NAME, "UICamera/Loadout/OpenLeaderboard", timeout: 10); }
-        public AltObject SettingsButton { get => Driver.WaitForObject(By.NAME, "UICamera/Loadout/SettingButton", timeout: 10); }
-        public AltObject MissionButton { get => Driver.WaitForObject(By.NAME, "UICamera/Loadout/MissionButton", timeout: 10); }
-        public AltObject RunButton { get => Driver.WaitForObject(By.NAME, "UICamera/Loadout/StartButton", timeout: 10); }
+        public AltObject StoreButton { get => Driver.WaitForObject(By.NAME, "StoreButton", timeout: 10); }
+        public AltObject LeaderBoardButton { get => Driver.WaitForObject(By.NAME, "OpenLeaderboard", timeout: 10); }
+        public AltObject SettingsButton { get => Driver.WaitForObject(By.NAME, "SettingButton", timeout: 10); }
+        public AltObject MissionButton { get => Driver.WaitForObject(By.NAME, "MissionButton", timeout: 10); }
+        public AltObject RunButton { get => Driver.WaitForObject(By.NAME, "StartButton", timeout: 10); }
         public AltObject CharacterName { get => Driver.WaitForObject(By.NAME, "CharName", timeout: 10); }
-        public AltObject ThemeName { get => Driver.WaitForObject(By.NAME, "UICamera/Loadout/ThemeZone", timeout: 10); }
+        public AltObject ThemeName { get => Driver.WaitForObject(By.NAME, "ThemeZone", timeout: 10); }
         public bool IsDisplayed()
         {
             if (StoreButton != null && LeaderBoardButton != null && SettingsButton != null && MissionButton != null && RunButton != null && CharacterName != null && ThemeName != null)

--- a/TestsAltTrashCatCSharp/pages/PauseOverlayPage.cs
+++ b/TestsAltTrashCatCSharp/pages/PauseOverlayPage.cs
@@ -8,9 +8,9 @@ namespace alttrashcat_tests_csharp.pages
         {
         }
 
-        public AltObject ResumeButton { get => Driver.WaitForObject(By.NAME, "Game/PauseMenu/Resume", timeout: 2); }
-        public AltObject MainMenuButton { get => Driver.WaitForObject(By.NAME, "Game/PauseMenu/Exit", timeout: 2); }
-        public AltObject Title { get => Driver.WaitForObject(By.NAME, "Game/PauseMenu/Text", timeout: 2); }
+        public AltObject ResumeButton { get => Driver.WaitForObject(By.PATH, "//Game/PauseMenu/Resume", timeout: 2); }
+        public AltObject MainMenuButton { get => Driver.WaitForObject(By.NAME, "Exit", timeout: 2); }
+        public AltObject Title { get => Driver.WaitForObject(By.NAME, "Text", timeout: 2); }
 
         public bool IsDisplayed()
         {


### PR DESCRIPTION
In this PR was updated the second parameter of the wait_for_object method to be consistent with the By class.
These are the results of the tests after the changes:
![image](https://user-images.githubusercontent.com/113912901/223107348-396bbdba-d44b-4cbd-a3b9-506e66d9b28d.png)
